### PR TITLE
downgrade Firebase due to bug

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -3,15 +3,36 @@ var Constants = require('../constants');
 var $ = require("jquery");
 var _ = require("underscore");
 
-var firebase = require('firebase')
-var config = {
-    apiKey: "AIzaSyCAAUrjrCNH_xCigW0T9qZxqeuaUpfcKmw",
-    authDomain: "reading-challenge.firebaseapp.com",
-    databaseURL: "https://reading-challenge.firebaseio.com",
-    storageBucket: "firebase-reading-challenge.appspot.com",
-};
-firebase.initializeApp(config);
-db = firebase.database();
+
+/////////////////////////////////////////////////////////
+// Downgrading to firebase 2.4, since newsest version does not work w/react
+// see:  https://medium.com/@Pier/firebase-is-broken-for-react-native-7f78b7a066da#.gotw818vu
+// and PR: https://github.com/ipam73/reading-challenge/commit/35247388d6ccc29a8dfd2bb1768da3e13a2c07df
+// var firebase = require('firebase')
+// var config = {
+//     apiKey: "AIzaSyCAAUrjrCNH_xCigW0T9qZxqeuaUpfcKmw",
+//     authDomain: "reading-challenge.firebaseapp.com",
+//     databaseURL: "https://reading-challenge.firebaseio.com",
+//     storageBucket: "firebase-reading-challenge.appspot.com",
+// };
+// firebase.initializeApp(config);
+// db = firebase.database();
+/////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////
+// Temporary workaround until Firebase fixes bug
+var Firebase = require('firebase');
+var firebaseURI = "https://reading-challenge.firebaseio.com/";
+
+function setFirebaseRef(ref) {
+  return {
+    type: 'FIREBASE_REF_SET',
+    value: ref,
+  };
+}
+/////////////////////////////////////////////////////////////
+
+
 
 // helper function for ajax calls
 function getCookie(name) {
@@ -88,7 +109,12 @@ function getStudentList() {
   console.log("ACTIONS: getStudentList AGAIN ASKFJ PAM");
   return (dispatch, getState) => {
     // TODO: use parentID instead of 1
-    var ref = db.ref("/parents/1");
+    var ref = new Firebase(firebaseURI + "parents/1");
+
+    ///////////////////////////////////////////////////////////////////////
+    // temporarily commenting out until firebase fixes bug, see top of file
+    // var ref = db.ref("/parents/1");
+
     return ref.child("students").once("value", (snapshot) => {
       dispatch(setStudentList(snapshot.val()));
     });

--- a/lib/students/index.coffee
+++ b/lib/students/index.coffee
@@ -1,9 +1,17 @@
 _ = require "underscore"
 config = require "#{__dirname}/../../web/config"
 
-firebase = require('firebase')
-firebase.initializeApp { serviceAccount: config.FIREBASE_ACCOUNT, databaseURL: "https://reading-challenge.firebaseio.com" }
-db = firebase.database()
+###############################################################################
+## Downgrading to firebase 2.4, since newsest version does not work w/react
+## see:  https://medium.com/@Pier/firebase-is-broken-for-react-native-7f78b7a066da#.gotw818vu
+## and PR: https://github.com/ipam73/reading-challenge/commit/35247388d6ccc29a8dfd2bb1768da3e13a2c07df
+# firebase = require('firebase')
+# firebase.initializeApp { serviceAccount: config.FIREBASE_ACCOUNT, databaseURL: "https://reading-challenge.firebaseio.com" }
+# db = firebase.database()
+###############################################################################
+
+Firebase = require('firebase')
+firebaseURI = "https://reading-challenge.firebaseio.com/"
 
 ### student schema
   {
@@ -31,7 +39,11 @@ save_student = (student_id, first_name, school_id, school_name, district_id, gra
     grade: grade
     total_mins: 0
 
-  parentsRef = db.ref("/parents/1")
+  ## Downgrading to firebase 2.4, since newsest version does not work w/react
+  # parentsRef = db.ref("/parents/1")
+  parentsRef = new Firebase(firebaseURI + "parents/" + "1")
+
+
   studentsRef = parentsRef.child("students/#{student_id}")
 
   # TODO: check for errors here. 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express-session": "^1.13.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
-    "firebase": "^3.0.3",
+    "firebase": "^2.4.2",
     "jade": "^1.11.0",
     "jquery": "^2.2.0",
     "jsx-loader": "^0.13.2",


### PR DESCRIPTION
Bad news, Firebase v3 doesn't work with react-native:
see - https://medium.com/@Pier/firebase-is-broken-for-react-native-7f78b7a066da#.wz03wj7no

I've added comments here and downgraded, since this was blocking development on native.  Does v2 support auth?  If not, we can talk alternatives (maybe using v3 for web, and somehow v2 for rest of the repo?)
